### PR TITLE
Refactor upload screen with ViewModel

### DIFF
--- a/app/src/main/java/com/example/sensortracking/ui/screens/upload/UploadScreen.kt
+++ b/app/src/main/java/com/example/sensortracking/ui/screens/upload/UploadScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
 import androidx.compose.material.icons.filled.MoreVert
@@ -25,19 +26,52 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.platform.LocalContext
+import androidx.documentfile.provider.DocumentFile
+import com.example.sensortracking.util.CSVParser
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
 import com.example.sensortracking.data.WarehouseMap
 import com.example.sensortracking.ui.screens.upload.uploadScreenDialog.FloorPlanSelectionDialog
+import com.example.sensortracking.ui.screens.upload.uploadScreenDialog.CustomFloorPlanDialog
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.runtime.collectAsState
+import com.example.sensortracking.ui.screens.upload.CustomFloorPlanInfo
+import com.example.sensortracking.ui.screens.upload.UploadScreenViewModel
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun UploadScreen(
-    onFloorPlanSelected: (WarehouseMap) -> Unit = {}
+    onFloorPlanSelected: (WarehouseMap) -> Unit = {},
+    viewModel: UploadScreenViewModel = viewModel()
 ) {
+    val uiState by viewModel.uiState.collectAsState()
+    val context = LocalContext.current
     var showFloorPlanDialog by remember { mutableStateOf(false) }
     var selectedFloorPlan by remember { mutableStateOf<WarehouseMap?>(null) }
+    var showCustomDialog by remember { mutableStateOf(false) }
+    var customCsvUri by remember { mutableStateOf<android.net.Uri?>(null) }
+    var pendingCustomPlan by remember { mutableStateOf<CustomFloorPlanInfo?>(null) }
+
+    val exampleMetadata = remember(context) {
+        val csvData = CSVParser.parseCSVFile(context, "example-wh-map.csv")
+        val rows = csvData?.size ?: 0
+        val cols = csvData?.firstOrNull()?.size ?: 0
+        val size = try { context.assets.openFd("example-wh-map.csv").length } catch (e: Exception) { 0L }
+        Triple(rows, cols, size)
+    }
+
+    val openDocumentLauncher = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.OpenDocument()
+    ) { uri ->
+        if (uri != null) {
+            customCsvUri = uri
+            showCustomDialog = true
+        }
+    }
     
     Scaffold(
         topBar = {
@@ -64,25 +98,40 @@ fun UploadScreen(
                     style = MaterialTheme.typography.headlineSmall
                 )
             }
-            
+
             item {
+                val (rows, cols, size) = exampleMetadata
                 FloorPlanCard(
                     title = "Example Warehouse (CSV)",
-                    description = "Sample warehouse layout with storage locations and aisles",
-                    onSelect = {
-                        showFloorPlanDialog = true
-                    }
+                    description = "$rows rows, $cols columns, ${size} bytes",
+                    onSelect = { showFloorPlanDialog = true }
                 )
             }
-            
+
+            items(uiState.customFloorPlans.size) { index ->
+                val plan = uiState.customFloorPlans[index]
+                FloorPlanCard(
+                    title = plan.title,
+                    description = "${plan.rows} rows, ${plan.columns} columns, ${plan.sizeBytes} bytes",
+                    onSelect = { onFloorPlanSelected(plan.map) }
+                )
+            }
+
             item {
                 FloorPlanCard(
                     title = "Upload Custom Floor Plan",
-                    description = "Upload your own Excel floor plan (Coming Soon)",
+                    description = "Upload your own CSV floor plan",
                     onSelect = {
-                        // TODO: Implement file upload
+                        openDocumentLauncher.launch(
+                            arrayOf(
+                                "text/csv",
+                                "text/comma-separated-values",
+                                "text/plain",
+                                "application/vnd.ms-excel"
+                            )
+                        )
                     },
-                    enabled = false
+                    enabled = true
                 )
             }
         }
@@ -98,6 +147,36 @@ fun UploadScreen(
             onDismiss = { showFloorPlanDialog = false },
             onFloorPlanLoaded = { warehouseMap ->
                 selectedFloorPlan = warehouseMap
+            }
+        )
+    }
+
+    if (showCustomDialog && customCsvUri != null) {
+        CustomFloorPlanDialog(
+            csvUri = customCsvUri!!,
+            onConfirm = {
+                pendingCustomPlan?.let {
+                    viewModel.addCustomFloorPlan(it)
+                    onFloorPlanSelected(it.map)
+                }
+                showCustomDialog = false
+                customCsvUri = null
+                pendingCustomPlan = null
+            },
+            onDismiss = {
+                showCustomDialog = false
+                customCsvUri = null
+                pendingCustomPlan = null
+            },
+            onFloorPlanLoaded = { warehouseMap, sizeBytes ->
+                val name = DocumentFile.fromSingleUri(context, customCsvUri!!)?.name ?: "Custom Floor Plan"
+                pendingCustomPlan = CustomFloorPlanInfo(
+                    title = name,
+                    rows = warehouseMap.height,
+                    columns = warehouseMap.width,
+                    sizeBytes = sizeBytes,
+                    map = warehouseMap
+                )
             }
         )
     }

--- a/app/src/main/java/com/example/sensortracking/ui/screens/upload/UploadScreenViewModel.kt
+++ b/app/src/main/java/com/example/sensortracking/ui/screens/upload/UploadScreenViewModel.kt
@@ -1,0 +1,32 @@
+package com.example.sensortracking.ui.screens.upload
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import com.example.sensortracking.data.WarehouseMap
+
+/** Information about a custom uploaded floor plan. */
+data class CustomFloorPlanInfo(
+    val title: String,
+    val rows: Int,
+    val columns: Int,
+    val sizeBytes: Long,
+    val map: WarehouseMap
+)
+
+/** UI state for [UploadScreen]. */
+data class UploadScreenUiState(
+    val customFloorPlans: List<CustomFloorPlanInfo> = emptyList()
+)
+
+class UploadScreenViewModel : ViewModel() {
+    private val _uiState = MutableStateFlow(UploadScreenUiState())
+    val uiState: StateFlow<UploadScreenUiState> = _uiState.asStateFlow()
+
+    /** Add a new custom floor plan to the list. */
+    fun addCustomFloorPlan(plan: CustomFloorPlanInfo) {
+        _uiState.update { it.copy(customFloorPlans = it.customFloorPlans + plan) }
+    }
+}

--- a/app/src/main/java/com/example/sensortracking/ui/screens/upload/uploadScreenDialog/CustomFloorPlanDialog.kt
+++ b/app/src/main/java/com/example/sensortracking/ui/screens/upload/uploadScreenDialog/CustomFloorPlanDialog.kt
@@ -1,0 +1,81 @@
+package com.example.sensortracking.ui.screens.upload.uploadScreenDialog
+
+import android.net.Uri
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.example.sensortracking.data.WarehouseMap
+import com.example.sensortracking.sensor.pdr.WarehouseMapProcessor
+import com.example.sensortracking.util.CSVParser
+
+@Composable
+fun CustomFloorPlanDialog(
+    csvUri: Uri,
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit,
+    onFloorPlanLoaded: (WarehouseMap, Long) -> Unit
+) {
+    val context = LocalContext.current
+    var isLoading by remember { mutableStateOf(true) }
+    var errorMessage by remember { mutableStateOf<String?>(null) }
+
+    LaunchedEffect(csvUri) {
+        try {
+            val fileDescriptor = context.contentResolver.openFileDescriptor(csvUri, "r")
+            val fileSize = fileDescriptor?.statSize ?: 0L
+            fileDescriptor?.close()
+
+            val csvData = CSVParser.parseCSVUri(context, csvUri)
+            if (csvData != null) {
+                val warehouseMapProcessor = WarehouseMapProcessor()
+                val warehouseMap = warehouseMapProcessor.parseWarehouseMap(csvData)
+                onFloorPlanLoaded(warehouseMap, fileSize)
+            } else {
+                errorMessage = "Failed to load floor plan"
+            }
+        } catch (e: Exception) {
+            errorMessage = "Error loading floor plan: ${e.message}"
+        } finally {
+            isLoading = false
+        }
+    }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Load Custom Floor Plan") },
+        text = {
+            Column {
+                if (isLoading) {
+                    CircularProgressIndicator(modifier = Modifier.align(Alignment.CenterHorizontally))
+                    Spacer(modifier = Modifier.height(16.dp))
+                    Text("Loading floor plan...")
+                } else if (errorMessage != null) {
+                    Text(text = errorMessage!!, color = MaterialTheme.colorScheme.error)
+                } else {
+                    Text("Floor plan loaded successfully!")
+                }
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm, enabled = !isLoading && errorMessage == null) {
+                Text("Use This Floor Plan")
+            }
+        },
+        dismissButton = { TextButton(onClick = onDismiss) { Text("Cancel") } }
+    )
+}

--- a/app/src/main/java/com/example/sensortracking/util/CSVParser.kt
+++ b/app/src/main/java/com/example/sensortracking/util/CSVParser.kt
@@ -1,6 +1,7 @@
 package com.example.sensortracking.util
 
 import android.content.Context
+import android.net.Uri
 import java.io.BufferedReader
 import java.io.InputStreamReader
 
@@ -20,6 +21,29 @@ object CSVParser {
             reader.close()
             inputStream.close()
             
+            lines.toTypedArray()
+        } catch (e: Exception) {
+            e.printStackTrace()
+            null
+        }
+    }
+
+    fun parseCSVUri(context: Context, uri: Uri): Array<Array<String>>? {
+        return try {
+            val inputStream = context.contentResolver.openInputStream(uri)
+                ?: return null
+            val reader = BufferedReader(InputStreamReader(inputStream))
+            val lines = mutableListOf<Array<String>>()
+
+            var line: String?
+            while (reader.readLine().also { line = it } != null) {
+                val values = parseCSVLine(line!!)
+                lines.add(values)
+            }
+
+            reader.close()
+            inputStream.close()
+
             lines.toTypedArray()
         } catch (e: Exception) {
             e.printStackTrace()


### PR DESCRIPTION
## Summary
- replace custom plan state with a ViewModel
- keep a list of uploaded plans in `UploadScreenViewModel`
- show floor plan cards from view model state

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889c849b988833091f0f1823f3baabf