### PR TITLE
Implement persistent floor plan storage and UI tweaks

### DIFF
--- a/app/src/main/java/com/example/sensortracking/data/PDRData.kt
+++ b/app/src/main/java/com/example/sensortracking/data/PDRData.kt
@@ -1,5 +1,8 @@
 package com.example.sensortracking.data
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class Position(
     val x: Float,
     val y: Float

--- a/app/src/main/java/com/example/sensortracking/data/WarehouseMap.kt
+++ b/app/src/main/java/com/example/sensortracking/data/WarehouseMap.kt
@@ -1,5 +1,8 @@
 package com.example.sensortracking.data
 
+import kotlinx.serialization.Serializable
+
+@Serializable
 data class WarehouseCell(
     val x: Int,
     val y: Int,
@@ -7,6 +10,7 @@ data class WarehouseCell(
     val storageLocation: String? = null
 )
 
+@Serializable
 enum class CellType {
     STORAGE,      // Non-walkable Storage location (B02, C80, etc.)
     AISLE,        // Walkable aisle space
@@ -15,6 +19,7 @@ enum class CellType {
     END           // Ending point
 }
 
+@Serializable
 data class WarehouseMap(
     val width: Int,
     val height: Int,

--- a/app/src/main/java/com/example/sensortracking/ui/screens/SettingsScreen.kt
+++ b/app/src/main/java/com/example/sensortracking/ui/screens/SettingsScreen.kt
@@ -15,7 +15,7 @@ fun SettingsScreen(navController: NavController) {
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Intellinum") },
+                title = { Text("Settings") },
                 actions = {
                     IconButton(onClick = { /* TODO: More options */ }) {
                         Icon(Icons.Default.MoreVert, contentDescription = "More options")

--- a/app/src/main/java/com/example/sensortracking/ui/screens/track/GridFloorPlanArea.kt
+++ b/app/src/main/java/com/example/sensortracking/ui/screens/track/GridFloorPlanArea.kt
@@ -10,10 +10,12 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.Path
 import androidx.compose.ui.graphics.drawscope.Stroke
 import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.graphics.drawscope.rotate
 import com.example.sensortracking.data.CellType
 import com.example.sensortracking.data.Position
 import com.example.sensortracking.data.WarehouseMap
@@ -24,6 +26,7 @@ fun GridFloorPlanArea(
     zoom: Float,
     onZoomChange: (Float) -> Unit,
     userPosition: Position,
+    heading: Float,
     area: Area,
     pathHistory: List<Position> = emptyList(),
     warehouseMap: WarehouseMap? = null
@@ -65,8 +68,16 @@ fun GridFloorPlanArea(
             val centerX = size.width / 2f
             val centerY = size.height / 2f
 
-            val offsetX = centerX - (startX + userX)
-            val offsetY = centerY - (startY + userY)
+            var offsetX = centerX - (startX + userX)
+            var offsetY = centerY - (startY + userY)
+
+            val minOffsetX = size.width - (startX + gridWidth)
+            val maxOffsetX = -startX
+            val minOffsetY = size.height - (startY + gridHeight)
+            val maxOffsetY = -startY
+
+            offsetX = offsetX.coerceIn(minOffsetX, maxOffsetX)
+            offsetY = offsetY.coerceIn(minOffsetY, maxOffsetY)
 
             if (warehouseMap != null) {
                 drawWarehouseMap(warehouseMap, startX + offsetX, startY + offsetY, cellSize)
@@ -113,7 +124,17 @@ fun GridFloorPlanArea(
             val posX = startX + offsetX + (userPosition.x / maxX) * gridWidth
             val posY = startY + offsetY + (userPosition.y / maxY) * gridHeight
 
-            drawCircle(color = Color.Red, radius = 8f, center = Offset(posX, posY))
+            val arrowSize = 12f
+            val path = Path().apply {
+                moveTo(posX, posY - arrowSize)
+                lineTo(posX - arrowSize, posY + arrowSize)
+                lineTo(posX + arrowSize, posY + arrowSize)
+                close()
+            }
+
+            rotate(degrees = heading, pivot = Offset(posX, posY)) {
+                drawPath(path = path, color = Color.Red)
+            }
         }
     }
 }

--- a/app/src/main/java/com/example/sensortracking/ui/screens/track/TrackScreen.kt
+++ b/app/src/main/java/com/example/sensortracking/ui/screens/track/TrackScreen.kt
@@ -103,7 +103,7 @@ fun TrackScreen(
     if (showStartDialog) {
         StartTrackingDialog(
             onSelectFloorPlan = { navController?.navigate("upload") },
-            onUploadFloorPlan = { /* TODO: Upload new floor plan */ },
+            onUploadFloorPlan = { navController?.navigate("upload") },
             onNoFloorPlan = {
                 viewModel.clearWarehouseMap()
                 showStartDialog = false
@@ -191,7 +191,7 @@ fun TrackScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("Intellinum") },
+                title = { Text("Track") },
                 actions = {
                     IconButton(onClick = { /* TODO: More options */ }) {
                         Icon(Icons.Default.MoreVert, contentDescription = "More options")
@@ -211,6 +211,7 @@ fun TrackScreen(
                         viewModel.onZoomChange(clamped)
                     },
                     userPosition = uiState.currentPosition,
+                    heading = uiState.currentHeading,
                     area = uiState.area,
                     pathHistory = viewModel.getPathHistory(),
                     warehouseMap = uiState.warehouseMap

--- a/app/src/main/java/com/example/sensortracking/ui/screens/upload/UploadScreen.kt
+++ b/app/src/main/java/com/example/sensortracking/ui/screens/upload/UploadScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ChevronRight
+import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -27,6 +28,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.runtime.LaunchedEffect
 import androidx.documentfile.provider.DocumentFile
 import com.example.sensortracking.util.CSVParser
 import androidx.compose.ui.Alignment
@@ -50,6 +52,7 @@ fun UploadScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
     val context = LocalContext.current
+    LaunchedEffect(Unit) { viewModel.initialize(context) }
     var showFloorPlanDialog by remember { mutableStateOf(false) }
     var selectedFloorPlan by remember { mutableStateOf<WarehouseMap?>(null) }
     var showCustomDialog by remember { mutableStateOf(false) }
@@ -109,7 +112,8 @@ fun UploadScreen(
                 FloorPlanCard(
                     title = plan.title,
                     description = "${plan.rows} rows, ${plan.columns} columns, ${plan.sizeBytes} bytes",
-                    onSelect = { onFloorPlanSelected(plan.map) }
+                    onSelect = { onFloorPlanSelected(plan.map) },
+                    onDelete = { viewModel.deleteCustomFloorPlan(plan) }
                 )
             }
 
@@ -179,7 +183,13 @@ fun UploadScreen(
 }
 
 @Composable
-fun FloorPlanCard(title: String, description: String, onSelect: () -> Unit, enabled: Boolean = true) {
+fun FloorPlanCard(
+    title: String,
+    description: String,
+    onSelect: () -> Unit,
+    onDelete: (() -> Unit)? = null,
+    enabled: Boolean = true
+) {
     Card(
         modifier = Modifier.fillMaxWidth(),
         onClick = { if (enabled) onSelect() },
@@ -205,12 +215,21 @@ fun FloorPlanCard(title: String, description: String, onSelect: () -> Unit, enab
                         color = MaterialTheme.colorScheme.onSurfaceVariant
                     )
                 }
-                Icon(
-                    imageVector = Icons.Default.ChevronRight,
-                    contentDescription = "Select",
-                    tint = if (enabled) MaterialTheme.colorScheme.primary 
-                           else MaterialTheme.colorScheme.onSurfaceVariant
-                )
+                if (onDelete != null) {
+                    IconButton(onClick = onDelete, enabled = enabled) {
+                        Icon(
+                            imageVector = Icons.Default.Delete,
+                            contentDescription = "Delete",
+                            tint = if (enabled) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onSurfaceVariant
+                        )
+                    }
+                } else {
+                    Icon(
+                        imageVector = Icons.Default.ChevronRight,
+                        contentDescription = "Select",
+                        tint = if (enabled) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant
+                    )
+                }
             }
         }
     }

--- a/app/src/main/java/com/example/sensortracking/ui/screens/upload/UploadScreenViewModel.kt
+++ b/app/src/main/java/com/example/sensortracking/ui/screens/upload/UploadScreenViewModel.kt
@@ -1,19 +1,24 @@
 package com.example.sensortracking.ui.screens.upload
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import com.example.sensortracking.data.WarehouseMap
+import kotlinx.serialization.Serializable
+import com.example.sensortracking.util.CustomFloorPlanStorage
 
 /** Information about a custom uploaded floor plan. */
+@Serializable
 data class CustomFloorPlanInfo(
     val title: String,
     val rows: Int,
     val columns: Int,
     val sizeBytes: Long,
-    val map: WarehouseMap
+    val map: WarehouseMap,
+    val fileName: String? = null
 )
 
 /** UI state for [UploadScreen]. */
@@ -22,11 +27,28 @@ data class UploadScreenUiState(
 )
 
 class UploadScreenViewModel : ViewModel() {
+    private var storage: CustomFloorPlanStorage? = null
     private val _uiState = MutableStateFlow(UploadScreenUiState())
     val uiState: StateFlow<UploadScreenUiState> = _uiState.asStateFlow()
 
+    fun initialize(context: Context) {
+        storage = CustomFloorPlanStorage(context)
+        loadPlans()
+    }
+
+    private fun loadPlans() {
+        val plans = storage?.loadPlans() ?: emptyList()
+        _uiState.value = UploadScreenUiState(plans)
+    }
+
     /** Add a new custom floor plan to the list. */
     fun addCustomFloorPlan(plan: CustomFloorPlanInfo) {
-        _uiState.update { it.copy(customFloorPlans = it.customFloorPlans + plan) }
+        val stored = storage?.savePlan(plan) ?: plan
+        _uiState.update { it.copy(customFloorPlans = it.customFloorPlans + stored) }
+    }
+
+    fun deleteCustomFloorPlan(plan: CustomFloorPlanInfo) {
+        plan.fileName?.let { storage?.deletePlan(it) }
+        _uiState.update { it.copy(customFloorPlans = it.customFloorPlans - plan) }
     }
 }

--- a/app/src/main/java/com/example/sensortracking/util/CustomFloorPlanStorage.kt
+++ b/app/src/main/java/com/example/sensortracking/util/CustomFloorPlanStorage.kt
@@ -1,0 +1,39 @@
+package com.example.sensortracking.util
+
+import android.content.Context
+import com.example.sensortracking.ui.screens.upload.CustomFloorPlanInfo
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import java.io.File
+
+class CustomFloorPlanStorage(private val context: Context) {
+    private val dir = File(context.filesDir, "floor_plans")
+    private val json = Json { prettyPrint = true }
+
+    init {
+        if (!dir.exists()) dir.mkdirs()
+    }
+
+    fun loadPlans(): List<CustomFloorPlanInfo> {
+        return dir.listFiles()?.mapNotNull { file ->
+            runCatching { json.decodeFromString<CustomFloorPlanInfo>(file.readText()) }.getOrNull()
+        } ?: emptyList()
+    }
+
+    fun savePlan(plan: CustomFloorPlanInfo): CustomFloorPlanInfo {
+        if (!dir.exists()) dir.mkdirs()
+        val fileName = plan.fileName ?: sanitize(plan.title) + "_" + System.currentTimeMillis() + ".json"
+        val file = File(dir, fileName)
+        val withFile = plan.copy(fileName = fileName)
+        file.writeText(json.encodeToString(withFile))
+        return withFile
+    }
+
+    fun deletePlan(fileName: String) {
+        val file = File(dir, fileName)
+        if (file.exists()) file.delete()
+    }
+
+    private fun sanitize(name: String): String = name.replace(Regex("[^A-Za-z0-9_]"), "_")
+}


### PR DESCRIPTION
- persist uploaded floor plans on device
- allow deleting floor plans from the list
- fix dialog navigation for uploading floor plans
- draw user position as heading-aware arrow and clamp zoom
- rename top bars for Track and Settings screens